### PR TITLE
RMET-4342 - Android16 opt out large screens

### DIFF
--- a/card.io/build.gradle
+++ b/card.io/build.gradle
@@ -25,7 +25,7 @@ android {
         buildFeatures {
             buildConfig = true
         }
-        versionName = "5.5.1-OS2"
+        versionName = "5.5.1-OS3"
         buildTypes.configureEach {
             buildConfigField "String", "CARD_IO_SDK_VERSION", "\"$versionName\""
         }

--- a/card.io/src/main/AndroidManifest.xml
+++ b/card.io/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
         <activity android:name="io.card.payment.CardIOActivity"
             android:configChanges="keyboardHidden|orientation"
             android:enableOnBackInvokedCallback="true"
-            tools:targetApi="33" />
+            tools:targetApi="33">
+            <property android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY" android:value="true" />
+        </activity>
         <activity android:name="io.card.payment.DataEntryActivity"
             android:enableOnBackInvokedCallback="true"
             tools:targetApi="33" />

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,6 +1,10 @@
 card.io Android SDK change log and release notes
 ================================================
 
+5.5.1-OS3
+----
+* Add PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY opt-out for target Android 16 on large screens 
+
 5.5.1-OS2
 ----
 * Remove deprecated onBackPressed and use default back navigation instead, to support predictive back in Android 13+.


### PR DESCRIPTION
Adds an opt-out property for large screens for `CardIOActivity`.

Specific to [target Android 16 changes](https://developer.android.com/about/versions/16/behavior-changes-16#large-screens-form-factors).

Other activities are not required, only `CardIOActivity` tries to restrict orientation.

This is not an actual fix, and will no longer work in Android 17 (which will come out sometime next year probably). 
Card IO on large screens doesn't really look the best even before Android 16 (the scan screen gets letterboxed on tablets).
However, the effort to make this SDK look "nice" on large-screens is fairly substantial, and will not be addressed at the moment.